### PR TITLE
Make password search case insensitive by default.

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -6,7 +6,7 @@ basecommand=$(echo "$0" | gawk '{ print $1 }')
 
 # set default settings
 _rofi () {
-    rofi -kb-accept-entry "!Return" "$@"
+    rofi -i -kb-accept-entry "!Return" "$@"
 }
 
 # We expect to find these fields in pass(1)'s output


### PR DESCRIPTION
Having the search be case insensitive seems by default seems like intuitive behavior to me. When I first installed this took me a moment since all my pass files are capitalized.

Sorry about the drive by pull, normally I would open an issue to discuss about it, but since I could do the edit in three chars in the Github interface, I figured why not make it a pull.